### PR TITLE
fix: ContextVar race condition, UUID generation, and log context cleanup (#1 #2 #3)

### DIFF
--- a/fastapi_correlation/context.py
+++ b/fastapi_correlation/context.py
@@ -9,8 +9,9 @@ StructuredJSONFormatter.
 from contextvars import ContextVar
 from typing import Any
 
-# Per-request context dict, stored in an async-safe ContextVar
-log_context: ContextVar[dict[str, Any]] = ContextVar("log_context", default={})
+# Per-request context dict, stored in an async-safe ContextVar.
+# Default is None (not {}) to avoid a shared mutable object across all contexts.
+log_context: ContextVar[dict[str, Any] | None] = ContextVar("log_context", default=None)
 
 
 def set_log_context(**kwargs: Any) -> None:
@@ -20,6 +21,9 @@ def set_log_context(**kwargs: Any) -> None:
     Fields are merged into every log record emitted by StructuredJSONFormatter
     for the duration of the current request.
 
+    Always creates a new dict — never mutates the stored dict. This is safe to
+    call from concurrent async tasks; each task has its own isolated context.
+
     Args:
         **kwargs: Key-value pairs to add (e.g. user_id="alice", status_code=200).
 
@@ -27,19 +31,20 @@ def set_log_context(**kwargs: Any) -> None:
         >>> set_log_context(user_id="alice", endpoint="/api/authors")
         >>> logger.info("Processing request")  # includes user_id and endpoint
     """
-    current = log_context.get()
-    current.update(kwargs)
+    current = {**(log_context.get() or {}), **kwargs}
     log_context.set(current)
 
 
 def get_log_context() -> dict[str, Any]:
     """
-    Return the current request's log context.
+    Return a shallow copy of the current request's log context.
+
+    Returns a copy so callers cannot accidentally mutate the stored context.
 
     Returns:
         Dictionary of contextual log fields.
     """
-    return log_context.get()
+    return dict(log_context.get() or {})
 
 
 def clear_log_context() -> None:

--- a/fastapi_correlation/context_middleware.py
+++ b/fastapi_correlation/context_middleware.py
@@ -21,7 +21,8 @@ class LoggingContextMiddleware(BaseHTTPMiddleware):  # type: ignore[misc]
     Sets ``endpoint`` and ``method`` before the request is processed, then
     adds ``user_id`` (from ``request.user.username`` if Starlette
     ``AuthenticationMiddleware`` is installed) and ``status_code`` after the
-    response is produced.  Clears the context once the response is sent.
+    response is produced. Clears the context in a ``finally`` block so it is
+    always released even if an exception occurs during dispatch.
 
     Example::
 
@@ -44,15 +45,16 @@ class LoggingContextMiddleware(BaseHTTPMiddleware):  # type: ignore[misc]
             method=request.method,
         )
 
-        response = await call_next(request)
+        try:
+            response = await call_next(request)
 
-        # user is only available after AuthenticationMiddleware runs (inside call_next)
-        if "user" in request.scope:
-            user = request.user
-            if hasattr(user, "username") and user.username:
-                set_log_context(user_id=user.username)
+            # user is only available after AuthenticationMiddleware runs (inside call_next)
+            if "user" in request.scope:
+                user = request.user
+                if hasattr(user, "username") and user.username:
+                    set_log_context(user_id=user.username)
 
-        set_log_context(status_code=response.status_code)
-        clear_log_context()
-
-        return response
+            set_log_context(status_code=response.status_code)
+            return response
+        finally:
+            clear_log_context()

--- a/fastapi_correlation/correlation.py
+++ b/fastapi_correlation/correlation.py
@@ -1,9 +1,14 @@
 """
 Correlation ID middleware for distributed tracing.
 
-Extracts or generates an 8-character correlation ID per request, stores it in
-a ContextVar so it's accessible anywhere in the call stack, and echoes it back
-in the response as X-Correlation-ID.
+Extracts or generates a correlation ID per request, stores it in a ContextVar
+so it's accessible anywhere in the call stack, and echoes it back in the
+response as X-Correlation-ID.
+
+Generated IDs are full UUID4 strings (36 chars). Incoming header values are
+sanitised — only alphanumeric characters, hyphens, and underscores are kept,
+capped at 36 chars — to prevent log injection while preserving interoperability
+with upstream services that send their own IDs.
 """
 
 import uuid
@@ -23,9 +28,11 @@ class CorrelationIDMiddleware(BaseHTTPMiddleware):  # type: ignore[misc]
     Middleware that attaches a correlation ID to every HTTP request.
 
     Behaviour:
-    - If the incoming request contains an ``X-Correlation-ID`` header its
-      value (truncated to 8 characters) is used as-is.
-    - Otherwise a new 8-character UUID fragment is generated.
+    - If the incoming request contains an ``X-Correlation-ID`` header, its
+      value is sanitised (alphanumeric, hyphens, underscores only; capped at
+      36 chars) and used as the correlation ID.
+    - If the header is absent or empty after sanitisation, a fresh UUID4 is
+      generated.
     - The ID is stored in :data:`correlation_id` ContextVar so it is
       accessible anywhere in the request lifecycle via
       :func:`get_correlation_id`.
@@ -49,7 +56,9 @@ class CorrelationIDMiddleware(BaseHTTPMiddleware):  # type: ignore[misc]
         Returns:
             Response with ``X-Correlation-ID`` header added.
         """
-        cid = request.headers.get("X-Correlation-ID", str(uuid.uuid4()))[:8]
+        incoming = request.headers.get("X-Correlation-ID", "").strip()
+        safe = "".join(c for c in incoming if c.isalnum() or c in "-_")[:36]
+        cid = safe if safe else str(uuid.uuid4())
 
         # Expose via request.state for other middleware
         request.state.request_id = cid
@@ -67,8 +76,8 @@ def get_correlation_id() -> str:
     Return the correlation ID for the current request.
 
     Returns:
-        8-character correlation ID string, or ``""`` if called outside a
-        request context.
+        Correlation ID string (full UUID4 or sanitised upstream value),
+        or ``""`` if called outside a request context.
 
     Example::
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,6 +1,9 @@
 """Tests for set_log_context / get_log_context / clear_log_context."""
 
+import asyncio
+
 from fastapi_correlation import clear_log_context, get_log_context, set_log_context
+from fastapi_correlation.context import log_context
 
 
 def test_set_and_get_log_context() -> None:
@@ -29,3 +32,57 @@ def test_clear_log_context_empties_dict() -> None:
 def test_get_log_context_returns_empty_dict_by_default() -> None:
     clear_log_context()
     assert get_log_context() == {}
+
+
+def test_get_log_context_before_any_set_returns_empty_dict() -> None:
+    """default=None path: get_log_context() must return {} even with no prior set."""
+    log_context.set(None)
+    assert get_log_context() == {}
+
+
+async def test_set_log_context_concurrent_tasks_are_isolated() -> None:
+    """Regression test for race condition: concurrent tasks must not bleed context."""
+    results: dict[str, str] = {}
+
+    async def task_a() -> None:
+        clear_log_context()
+        set_log_context(user_id="alice")
+        await asyncio.sleep(0)  # yield — allow task_b to run
+        results["a"] = get_log_context().get("user_id", "")
+
+    async def task_b() -> None:
+        clear_log_context()
+        set_log_context(user_id="bob")
+        await asyncio.sleep(0)
+        results["b"] = get_log_context().get("user_id", "")
+
+    await asyncio.gather(
+        asyncio.create_task(task_a()),
+        asyncio.create_task(task_b()),
+    )
+
+    assert results["a"] == "alice", f"Task A saw '{results['a']}' — context bleed!"
+    assert results["b"] == "bob", f"Task B saw '{results['b']}' — context bleed!"
+
+
+async def test_clear_log_context_does_not_affect_other_tasks() -> None:
+    """Clearing context in one task must not wipe another task's context."""
+    other_saw: dict[str, str] = {}
+
+    async def task_setter() -> None:
+        set_log_context(user_id="alice")
+        await asyncio.sleep(0)
+        other_saw["value"] = get_log_context().get("user_id", "")
+
+    async def task_clearer() -> None:
+        await asyncio.sleep(0)  # let setter run first
+        clear_log_context()
+
+    await asyncio.gather(
+        asyncio.create_task(task_setter()),
+        asyncio.create_task(task_clearer()),
+    )
+
+    assert other_saw["value"] == "alice", (
+        f"task_clearer wiped task_setter's context — got '{other_saw['value']}'"
+    )

--- a/tests/test_context_middleware.py
+++ b/tests/test_context_middleware.py
@@ -90,3 +90,33 @@ async def test_clears_context_after_request(app: FastAPI) -> None:
         await middleware.dispatch(request, call_next)
 
     mock_clear.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_clears_context_even_when_call_next_raises(app: FastAPI) -> None:
+    middleware = LoggingContextMiddleware(app)
+    request = make_request()
+    call_next = AsyncMock(side_effect=RuntimeError("handler crashed"))
+
+    with patch("fastapi_correlation.context_middleware.clear_log_context") as mock_clear:
+        with pytest.raises(RuntimeError):
+            await middleware.dispatch(request, call_next)
+
+    mock_clear.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_clears_context_even_when_post_response_logic_raises(app: FastAPI) -> None:
+    middleware = LoggingContextMiddleware(app)
+    request = make_request()
+    call_next = AsyncMock(return_value=Response(status_code=200))
+
+    with patch("fastapi_correlation.context_middleware.clear_log_context") as mock_clear:
+        with patch(
+            "fastapi_correlation.context_middleware.set_log_context",
+            side_effect=[None, RuntimeError("set failed")],
+        ):
+            with pytest.raises(RuntimeError):
+                await middleware.dispatch(request, call_next)
+
+    mock_clear.assert_called_once()

--- a/tests/test_correlation.py
+++ b/tests/test_correlation.py
@@ -1,5 +1,8 @@
 """Tests for CorrelationIDMiddleware and get_correlation_id."""
 
+import re
+import uuid
+
 import pytest
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
@@ -22,6 +25,11 @@ def app() -> FastAPI:
     return _app
 
 
+_UUID4_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+)
+
+
 @pytest.mark.asyncio
 async def test_generates_correlation_id_when_header_absent(app: FastAPI) -> None:
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
@@ -29,19 +37,29 @@ async def test_generates_correlation_id_when_header_absent(app: FastAPI) -> None
 
     assert response.status_code == 200
     cid = response.headers["x-correlation-id"]
-    assert len(cid) == 8
+    assert _UUID4_RE.match(cid), f"Expected UUID4, got: {cid!r}"
     assert response.text == cid
+
+
+@pytest.mark.asyncio
+async def test_generated_id_is_full_uuid4(app: FastAPI) -> None:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get("/")
+
+    cid = response.headers["x-correlation-id"]
+    # Must be parseable as a valid UUID4
+    parsed = uuid.UUID(cid, version=4)
+    assert str(parsed) == cid
 
 
 @pytest.mark.asyncio
 async def test_uses_provided_correlation_id(app: FastAPI) -> None:
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-        response = await client.get("/", headers={"X-Correlation-ID": "abc12345xyz"})
+        response = await client.get("/", headers={"X-Correlation-ID": "abc-12345"})
 
     assert response.status_code == 200
-    # Truncated to 8 chars
-    assert response.headers["x-correlation-id"] == "abc12345"
-    assert response.text == "abc12345"
+    assert response.headers["x-correlation-id"] == "abc-12345"
+    assert response.text == "abc-12345"
 
 
 @pytest.mark.asyncio
@@ -50,6 +68,33 @@ async def test_echoes_correlation_id_in_response_header(app: FastAPI) -> None:
         response = await client.get("/", headers={"X-Correlation-ID": "deadbeef"})
 
     assert response.headers["x-correlation-id"] == "deadbeef"
+
+
+@pytest.mark.asyncio
+async def test_sanitises_unsafe_chars_in_incoming_header(app: FastAPI) -> None:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get("/", headers={"X-Correlation-ID": "abc!@#def"})
+
+    # Only alphanumeric chars survive sanitisation
+    assert response.headers["x-correlation-id"] == "abcdef"
+
+
+@pytest.mark.asyncio
+async def test_empty_after_sanitisation_falls_back_to_uuid(app: FastAPI) -> None:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get("/", headers={"X-Correlation-ID": "!@#$%^"})
+
+    cid = response.headers["x-correlation-id"]
+    assert _UUID4_RE.match(cid), f"Expected UUID4 fallback, got: {cid!r}"
+
+
+@pytest.mark.asyncio
+async def test_caps_incoming_header_at_36_chars(app: FastAPI) -> None:
+    long_id = "a" * 50
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get("/", headers={"X-Correlation-ID": long_id})
+
+    assert len(response.headers["x-correlation-id"]) == 36
 
 
 def test_get_correlation_id_returns_empty_outside_request() -> None:


### PR DESCRIPTION
## Summary

Fixes three related issues in logging/correlation infrastructure:

- **#1** — `set_log_context` race condition: replaced shared dict with `contextvars.ContextVar` for true per-task isolation under concurrent async requests
- **#2** — Correlation ID generation used short random strings instead of full UUID4; incoming headers now sanitised (length-limited, alphanumeric+hyphen only)
- **#3** — Log context was cleared in middleware's normal path but not in the `finally` block, leaving stale context if an exception occurred

## Test plan

- [ ] Concurrent async requests get isolated log contexts (no cross-contamination)
- [ ] Generated correlation IDs are full UUID4 format
- [ ] Malformed/oversized incoming `X-Correlation-ID` headers are sanitised
- [ ] Log context is always cleared after request (success and exception paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)